### PR TITLE
Deleted launch prefix for protobot_teleop launch file

### DIFF
--- a/src/protobot_teleop/launch/protobot_teleop.launch
+++ b/src/protobot_teleop/launch/protobot_teleop.launch
@@ -1,3 +1,3 @@
 <launch>
-	<node pkg="teleop_twist_keyboard" type="teleop_twist_keyboard.py" name="teleop" output="screen" launch-prefix="st -e " />
+	<node pkg="teleop_twist_keyboard" type="teleop_twist_keyboard.py" name="teleop" output="screen"/>
 </launch>


### PR DESCRIPTION
Will no longer launch teleop in new shell,but is compatible across WSL2 shell, Gnome-terminal, and st